### PR TITLE
Fix Global Variable

### DIFF
--- a/src/ElegantOTA.cpp
+++ b/src/ElegantOTA.cpp
@@ -1,0 +1,3 @@
+#include "ElegantOTA.h"
+
+ElegantOtaClass ElegantOTA;

--- a/src/ElegantOTA.h
+++ b/src/ElegantOTA.h
@@ -237,5 +237,5 @@ class ElegantOtaClass{
         
 };
 
-ElegantOtaClass ElegantOTA;
+extern ElegantOtaClass ElegantOTA;
 #endif


### PR DESCRIPTION
I don't see a valid reason why the library singleton should be forced in the header, breaking the standard C\C++ compilation strategy, but maybe I'm missing the point.

https://github.com/ayushsharma82/ElegantOTA/issues/52