### PR TITLE
Hook up esp32-flashz lib to support compressed updates

### DIFF
--- a/examples/demo_zlib/platformio.ini
+++ b/examples/demo_zlib/platformio.ini
@@ -1,0 +1,45 @@
+[platformio]
+default_envs = flashz
+
+[common]
+framework = arduino
+platform = espressif32
+board = wemos_d1_mini32
+board_build.filesystem = littlefs
+lib_deps =
+    https://github.com/vortigont/ElegantOTA#esp32-flashz
+    HTTPClient
+    WiFiClientSecure
+    ;https://github.com/vortigont/esp32-flashz#v1.1.0
+build_flags =
+    -D BUILD_ENV=$PIOENV
+    -DELEGANTOTA_DEBUG=1
+upload_speed = 460800
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
+;extra_scripts =
+;    post:post_flashz.py
+
+
+[debug]
+build_flags =
+    -DCORE_DEBUG_LEVEL=5
+    -DLOG_LOCAL_LEVEL=ESP_LOG_DEBUG
+
+[env]
+extends = common
+
+; default Arduino ESP32
+[env:flashz]
+extends = env
+build_flags =
+    ${env.build_flags}
+    -DCORE_DEBUG_LEVEL=3
+    -DLOG_LOCAL_LEVEL=ESP_LOG_INFO
+
+; build lib with lot's of debug enabled
+[env:flashz_debug]
+extends = env
+build_flags =
+    ${env.build_flags}
+    ${debug.build_flags}

--- a/examples/demo_zlib/src/main.cpp
+++ b/examples/demo_zlib/src/main.cpp
@@ -1,0 +1,50 @@
+ /*
+  ElegantOTA Demo Example - This example intended to work with ESP32 family chips
+  -----
+  Author: Ayush Sharma ( https://github.com/ayushsharma82 )
+  
+  Important Notice: Star the repository on Github if you like the library! :)
+  Repository Link: https://github.com/ayushsharma82/ElegantOTA
+*/
+
+#include <WiFi.h>
+#include <WiFiClient.h>
+#include <WebServer.h>
+
+#include <ElegantOTA.h>
+
+const char* ssid = "WiFi_SSID";
+const char* password = "wifipass";
+
+WebServer server(80);
+
+
+void setup(void) {
+  Serial.begin(115200);
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid, password);
+  Serial.println("");
+
+  // Wait for connection
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("");
+  Serial.print("Connected to ");
+  Serial.println(ssid);
+  Serial.print("IP address: ");
+  Serial.println(WiFi.localIP());
+
+  server.on("/", []() {
+    server.send(200, "text/plain", "Hi! I am ESP32 :). You can upload some raw or zlib compressed images to me");
+  });
+
+  ElegantOTA.begin(&server);    // Start ElegantOTA
+  server.begin();
+  Serial.println("HTTP server started");
+}
+
+void loop(void) {
+  server.handleClient();
+}

--- a/library.json
+++ b/library.json
@@ -27,6 +27,12 @@
       "examples/*"
     ]
   },
+  "dependencies": [
+        {"owner": "vortigont",
+         "name": "esp32-flashz",
+         "version": "https://github.com/vortigont/esp32-flashz#v1.1.0",
+         "platforms": ["espressif32"]}
+  ],
   "build": {
     "libLDFMode": "chain+"
   },

--- a/src/ElegantESPServer.cpp
+++ b/src/ElegantESPServer.cpp
@@ -1,6 +1,9 @@
 #if defined(ARDUINO) && (defined(ESP32) || defined(ESP8266)) && ELEGANTOTA_USE_ASYNC_SERVER == 0
 #include "ElegantESPServer.h"
 
+#if defined(ESP32)
+#include "flashz.hpp"
+#endif
 
 ElegantESPServer::ElegantESPServer() {
 }
@@ -47,11 +50,13 @@ ElegantESPServer::ElegantESPServer() {
         }
 
         // Get & Set MD5
+        #ifndef ESP32   // no way to process MD5 for esp32's compressed images
         if (_server->hasArg("MD5")) {
             if(!Update.setMD5(_server->arg("MD5").c_str())) {
                 return _server->send(400, "text/plain", "MD5 parameter invalid");
             }
         }
+        #endif
 
         // Handle File Upload
         HTTPUpload& upload = _server->upload();
@@ -79,21 +84,44 @@ ElegantESPServer::ElegantESPServer() {
                 size_t fsSize = ((size_t) &_FS_end - (size_t) &_FS_start);
                 uint32_t maxSketchSpace = (ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000;
                 if (!Update.begin((cmd == U_FS)?fsSize:maxSketchSpace, cmd)){ // Start with max available size
-            #elif defined(ESP32)
-                int cmd = (upload.filename == "filesystem") ? U_SPIFFS : U_FLASH;
-                if (!Update.begin(UPDATE_SIZE_UNKNOWN, cmd)) { // Start with max available size
-            #endif
                     #if ELEGANTOTA_DEBUG == 1
-                        Update.printError(ELEGANTOTA_DEBUG_PORT);
+                        #ifdef ESP32
+                            FlashZ::getInstance().printError(ELEGANTOTA_DEBUG_PORT);
+                        #else
+                            Update.printError(ELEGANTOTA_DEBUG_PORT);
+                        #endif
                     #endif
                     _trigger_ota_fail();
                     return _server->send(500, "text/plain", "OTA update failed due to size constraints");
                 }
                 ELEGANTOTA_DEBUG_LOG("[ElegantOTA] OTA update Started: %s - %d bytes\n", upload.filename.c_str(), upload.totalSize);
+            #endif
+
         } else if (upload.status == UPLOAD_FILE_WRITE) {
             // Handle Upload Write
+            #if defined(ESP32)
+            if (!upload.totalSize){
+                int cmd = (upload.filename == "filesystem") ? U_SPIFFS : U_FLASH;
+                bool mode_z = (upload.buf[0] == ZLIB_HEADER);    // check if we have a compressed image
+
+                if (!(mode_z ? FlashZ::getInstance().beginz(UPDATE_SIZE_UNKNOWN, cmd) : FlashZ::getInstance().begin(UPDATE_SIZE_UNKNOWN, cmd))){
+                    #if ELEGANTOTA_DEBUG == 1
+                            FlashZ::getInstance().printError(ELEGANTOTA_DEBUG_PORT);
+                    #endif
+                    _trigger_ota_fail();
+                    return _server->send(500, "text/plain", "OTA update failed due to size constraints");
+                }
+                ELEGANTOTA_DEBUG_LOG("[ElegantOTA] OTA update Started: %s; mode_z: %s\n", upload.filename.c_str(), mode_z ? "yes" : "no");
+            }
+            #endif  // defined(ESP32)
+
+        #ifdef ESP32
+            if(FlashZ::getInstance().writez(upload.buf, upload.currentSize, false) != upload.currentSize){
+                FlashZ::getInstance().printError(ELEGANTOTA_DEBUG_PORT);
+        #else
             if (Update.write(upload.buf, upload.currentSize) != upload.currentSize) {
                 Update.printError(ELEGANTOTA_DEBUG_PORT);
+        #endif
                 _trigger_ota_fail();
                 return _server->send(500, "text/plain", "OTA update failed due to error while writing to flash");
             }
@@ -102,7 +130,16 @@ ElegantESPServer::ElegantESPServer() {
             _trigger_ota_progress(progress);
         } else if (upload.status == UPLOAD_FILE_END) {
             // Handle Upload End
+        #ifdef ESP32
+            if(FlashZ::getInstance().writez(upload.buf, upload.currentSize, true) != upload.currentSize){
+                _trigger_ota_fail();
+                ELEGANTOTA_DEBUG_LOG("[ElegantOTA] OTA Update failed unexpectedly (likely broken connection): status=%d\n", upload.status);
+                return FlashZ::getInstance().abortz();
+            }
+            if(FlashZ::getInstance().endz()){
+        #else
             if (Update.end(true)) { //true to set the size to the current progress
+        #endif
                 ELEGANTOTA_DEBUG_LOG("[ElegantOTA] OTA update Success: %u\n", upload.totalSize);
                 _trigger_ota_success();
             } else {
@@ -118,6 +155,10 @@ ElegantESPServer::ElegantESPServer() {
 
             _trigger_ota_end();
         } else {
+            #ifdef ESP32
+                FlashZ::getInstance().abortz();
+            #endif
+
             ELEGANTOTA_DEBUG_LOG("[ElegantOTA] OTA Update failed unexpectedly (likely broken connection): status=%d\n", upload.status);
         }
     });


### PR DESCRIPTION
@ayushsharma82 was a bit busy lately
So here is a test prototype with [esp32-flashz](https://github.com/vortigont/esp32-flashz) lib back-end for anyone dare to try. Both uncompressed and zlib-compressed images uploading supported for all esp32 platforms.
It works pretty fine on controller's side. But there are some 'but'`s with UI :)

 - for now it's just for WebServer's version, not for Async
 - I was unable to launch the UI at all from v3-alpha branch. It opens a pic and spins the spinner indefinitely. In network mon I can see a 404 for '/update/identity', whatever it means, that's all. Never mind, uploading works pretty fine with CLI `curl` tool
 - need to figure out what to do with MD5's for compressed images. It can't be applied to update's check. Not much of a use also, if file is broken on the way, than it will probably fail decompression anyway. For now md5 check is disabled for esp32. I think I can turn it back for uncompressed images, but need to decide what to do with front-end. Another option is to check md5 for compressed input and fail on end in case of a mismatch. But again, it will probably fail decompression before that
 - code style looks ugly an unreadable with all of those `#ifdef's, suppose would be better to split different arch types into separate cpp's 

Testing:
```
> pigz -9kzc firmware.bin | curl -v http://$ESPHOST/update -F file=@-
>   Trying 192.168.176.207:80...
> Connected to 192.168.176.207 (192.168.176.207) port 80 (#0)
> POST /update HTTP/1.1
> Host: 192.168.176.207
> User-Agent: curl/7.81.0
> Accept: */*
> Content-Length: 516519
> Content-Type: multipart/form-data; boundary=------------------------b019f13fd0aba242
> 
> We are completely uploaded and fine
```

ESP output:
```
IP address: 192.168.176.207
HTTP server started
[ElegantOTA] OTA update received: -
[ElegantOTA] OTA update Started: -; mode_z: yes
[ 60138][I][flashz.cpp:296] flash_cb(): [FLASHZ] flashed 32768 bytes
[ 60322][I][flashz.cpp:296] flash_cb(): [FLASHZ] flashed 32768 bytes
[ 60630][I][flashz.cpp:296] flash_cb(): [FLASHZ] flashed 32768 bytes
[ 60767][I][flashz.cpp:296] flash_cb(): [FLASHZ] flashed 32768 bytes
...
[ 64595][I][flashz.cpp:296] flash_cb(): [FLASHZ] flashed 32768 bytes
[ 64771][I][flashz.cpp:296] flash_cb(): [FLASHZ] flashed 32768 bytes
[ 65163][I][flashz.cpp:296] flash_cb(): [FLASHZ] flashed 32768 bytes
[ 65304][I][flashz.cpp:296] flash_cb(): [FLASHZ] flashed 32768 bytes
[ 65657][I][flashz.cpp:296] flash_cb(): [FLASHZ] flashed 32768 bytes
[ 65829][I][flashz.cpp:296] flash_cb(): [FLASHZ] flashed 32768 bytes
[ 66193][I][flashz.cpp:296] flash_cb(): [FLASHZ] flashed 32768 bytes
[ 66285][I][flashz.cpp:296] flash_cb(): [FLASHZ] flashed 18176 bytes
[ElegantOTA] OTA update Success: 516366
ets Jun  8 2016 00:22:57
```