### PR TITLE
Arduino 3 / ESP-IDF 5 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,85 +1,131 @@
 name: Arduino Library CI
 
-on: 
+on:
   push:
     paths-ignore:
-      - '**/**.md'
-      - '/keywords.txt'
-      - '/library.json'
-      - '/library.properties'
-      - '/ui'
-      - '/docs'
+      - "**/**.md"
+      - "/keywords.txt"
+      - "/library.json"
+      - "/library.properties"
+      - "/vue-frontend"
+      - "/docs"
   pull_request:
     paths-ignore:
-      - '**/**.md'
-      - '/keywords.txt'
-      - '/library.json'
-      - '/library.properties'
-      - '/ui'
-      - '/docs'
+      - "**/**.md"
+      - "/keywords.txt"
+      - "/library.json"
+      - "/library.properties"
+      - "/vue-frontend"
+      - "/docs"
 
 jobs:
-  Async_CI:
+  arduino:
+    name: arduino ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: package_esp32_index.json
+            core: esp32:esp32
+            board: esp32:esp32:esp32
+            index_url: https://espressif.github.io/arduino-esp32/package_esp32_index.json
+          - name: package_esp32_dev_index.json
+            core: esp32:esp32
+            board: esp32:esp32:esp32
+            index_url: https://espressif.github.io/arduino-esp32/package_esp32_dev_index.json
+          - name: package_esp8266com_index.json
+            core: esp8266:esp8266
+            board: esp8266:esp8266:huzzah
+            index_url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
+
     steps:
-      - uses: actions/setup-python@v1
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Arduino Lint
+        uses: arduino/arduino-lint-action@v1
         with:
-          python-version: '3.x'
-      
-      - uses: actions/checkout@v2
+          library-manager: update
 
-      - uses: actions/checkout@v2
-        with:
-           repository: ayushsharma82/ci-arduino
-           path: ci
+      - name: Install arduino-cli
+        run: curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=/usr/local/bin sh
 
-      - name: pre-install
-        run: bash ci/actions_install.sh
+      - name: Update core index
+        run: arduino-cli core update-index --additional-urls "${{ matrix.index_url }}"
 
-      - name: Set configuration
-        run: arduino-cli config set library.enable_unsafe_install true 
+      - name: Install core
+        run: arduino-cli core install --additional-urls "${{ matrix.index_url }}" ${{ matrix.core }}
 
-      - name: Install test dependencies
-        run: arduino-cli lib install --git-url https://github.com/me-no-dev/ESPAsyncWebServer --git-url https://github.com/me-no-dev/ESPAsyncTCP --git-url https://github.com/me-no-dev/AsyncTCP
-      
-      - name: Skip SyncDemo Example
-        run: |
-          cd examples
-          cd Demo
-          touch .esp32.test.skip
-          touch .esp8266.test.skip
+      - name: Install AsyncTCP
+        run: ARDUINO_LIBRARY_ENABLE_UNSAFE_INSTALL=true arduino-cli lib install --git-url https://github.com/mathieucarbou/AsyncTCP#v3.1.4
+
+      - name: Install ESPAsyncTCP
+        run: ARDUINO_LIBRARY_ENABLE_UNSAFE_INSTALL=true arduino-cli lib install --git-url https://github.com/mathieucarbou/esphome-ESPAsyncTCP#v2.0.0
+
+      - name: Install ESPAsyncWebServer
+        run: ARDUINO_LIBRARY_ENABLE_UNSAFE_INSTALL=true arduino-cli lib install --git-url https://github.com/mathieucarbou/ESPAsyncWebServer#v2.10.1
+
+      - name: Build Demo
+        run: arduino-cli compile --library . --warnings none -b ${{ matrix.board }} "examples/Demo/Demo.ino"
 
       - name: Configure ElegantOTA to Async Mode
         run: |
           cd src
           sed -i 's/ELEGANTOTA_USE_ASYNC_WEBSERVER 0/ELEGANTOTA_USE_ASYNC_WEBSERVER 1/' ElegantOTA.h
-      
-      - name: Test Async Demo
-        run: python3 ci/build_platform.py esp8266 esp32
 
-  Sync_CI:
+      - name: Build AsyncDemo
+        run: arduino-cli compile --library . --warnings none -b ${{ matrix.board }} "examples/AsyncDemo/AsyncDemo.ino"
+
+  platformio:
+    name: pio ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: esp32dev|arduino
+            board: esp32dev
+            platform: espressif32
+            opts:
+          - name: esp32dev|arduino-2
+            board: esp32dev
+            platform: espressif32@6.7.0
+            opts:
+          - name: esp32dev|arduino-3
+            board: esp32dev
+            platform: espressif32
+            opts: "--project-option 'platform_packages=platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.0, platform_packages=platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/arduino-esp32/releases/download/3.0.0/esp32-arduino-libs-3.0.0.zip'"
+          - name: esp32-s3-devkitc-1|arduino
+            board: esp32-s3-devkitc-1
+            platform: espressif32
+            opts:
+          - name: esp32-s3-devkitc-1|arduino-2
+            board: esp32-s3-devkitc-1
+            platform: espressif32@6.7.0
+            opts:
+          - name: esp32-s3-devkitc-1|arduino-3
+            board: esp32-s3-devkitc-1
+            platform: espressif32
+            opts: "--project-option 'platform_packages=platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.0, platform_packages=platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/arduino-esp32/releases/download/3.0.0/esp32-arduino-libs-3.0.0.zip'"
+          - name: huzzah|espressif8266
+            board: huzzah
+            platform: espressif8266
+            opts:
     steps:
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - name: Set up cache
+        uses: actions/cache@v4
         with:
-          python-version: '3.x'
-      
-      - uses: actions/checkout@v2
-
-      - uses: actions/checkout@v2
+          path: |
+            ~/.platformio
+            ~/.cache/pip
+          key: ${{ matrix.name }}
+      - uses: actions/setup-python@v5
         with:
-           repository: adafruit/ci-arduino
-           path: ci
+          python-version: "3.x"
+      - run: pip install platformio
+      - run: platformio platform install ${{ matrix.platform }}
 
-      - name: pre-install
-        run: bash ci/actions_install.sh
-
-      - name: Skip AsyncDemo Example
-        run: |
-          cd examples
-          cd AsyncDemo
-          touch .esp32.test.skip
-          touch .esp8266.test.skip
-
-      - name: Test Sync Demo
-        run: python3 ci/build_platform.py esp8266 esp32 picow_rp2040
+      - run: platformio ci "examples/Demo/Demo.ino" -l '.' -b ${{ matrix.board }} ${{ matrix.opts }}
+      - run: PLATFORMIO_BUILD_FLAGS="-DELEGANTOTA_USE_ASYNC_WEBSERVER=1" platformio ci "examples/AsyncDemo/AsyncDemo.ino" -l '.' -b ${{ matrix.board }} ${{ matrix.opts }}

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ node_modules
 .vscode
 /build
 /portal
+.pio

--- a/library.json
+++ b/library.json
@@ -15,6 +15,14 @@
       "maintainer": true
     }
   ],
+  "dependencies": [
+    {
+      "owner": "mathieucarbou",
+      "name": "ESP Async WebServer",
+      "version": "^2.10.1",
+      "platforms": ["espressif8266", "espressif32"]
+    }
+  ],
   "version": "3.1.1",
   "frameworks": "arduino",
   "platforms": ["espressif8266", "espressif32", "raspberrypi"]

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,40 @@
+[env]
+framework = arduino
+build_flags = 
+  -Wall -Wextra
+  -D CONFIG_ARDUHAL_LOG_COLORS
+  -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_DEBUG
+  -D ELEGANTOTA_USE_ASYNC_WEBSERVER=1
+lib_deps = 
+  mathieucarbou/Async TCP @ ^3.1.4
+  mathieucarbou/ESP Async WebServer @ 2.10.1
+upload_protocol = esptool
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder, log2file
+
+[platformio]
+lib_dir = .
+; src_dir = examples/Demo
+src_dir = examples/AsyncDemo
+
+[env:arduino]
+platform = espressif32
+board = esp32-s3-devkitc-1
+
+[env:arduino-2]
+platform = espressif32@6.7.0
+board = esp32-s3-devkitc-1
+
+[env:arduino-3]
+platform = espressif32
+platform_packages=
+  platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.0
+  platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/arduino-esp32/releases/download/3.0.0/esp32-arduino-libs-3.0.0.zip
+board = esp32-s3-devkitc-1
+
+[env:esp8266]
+platform = espressif8266
+board = huzzah
+lib_deps = 
+  mathieucarbou/ESP Async WebServer @ 2.10.1
+  esphome/ESPAsyncTCP-esphome @ 2.0.0


### PR DESCRIPTION
This PR updates the CI system and dependencies in order to make the library compatible with Arduino 3 / ESP-IDF 5, and of course Arduino 2.

The project itself does not require any change, except the library.json for PlatformIO projects, but alternate dependencies must be used, which have been updated:

- https://github.com/mathieucarbou/AsyncTCP
- https://github.com/mathieucarbou/ESPAsyncWebServer

Example:

```
lib_deps = 
  mathieucarbou/Async TCP @ ^3.1.4
  mathieucarbou/ESP Async WebServer @ 2.10.1
```

Note: the change to `https://github.com/mathieucarbou/esphome-ESPAsyncTCP#v2.0.0` is because ESPHome have deleted the library.properties file from the original fork.

You can see an sample of what will the CI look like here in my fork: https://github.com/mathieucarbou/ayushsharma82-ElegantOTA/actions/runs/8773016893