### PR TITLE
Handle LittleFS images in platformio_upload.py.

### DIFF
--- a/platformio_upload.py
+++ b/platformio_upload.py
@@ -42,8 +42,8 @@ def on_upload(source, target, env):
         parsed_url = urlparse(upload_url)
         host_ip = parsed_url.netloc
 
-        is_spiffs = source[0].name == "spiffs.bin"
-        file_type = "fs" if is_spiffs else "fr"
+        is_fs = source[0].name == "spiffs.bin" or source[0].name == "littlefs.bin"
+        file_type = "fs" if is_fs else "fr"
 
         # execute GET request
         start_url = f"{upload_url}/ota/start?mode={file_type}&hash={md5}"


### PR DESCRIPTION
Currently platofrmio_upload only supports SPIFFS. With this change, LittleFS is also detected and correctly handled. Without this change, the script assumes that LittleFS images are actually firmware, which will of course fail.