### PR TITLE
added example stopped loop() activity during update

### DIFF
--- a/examples/StopTrafficDemo/StopTrafficDemo.ino
+++ b/examples/StopTrafficDemo/StopTrafficDemo.ino
@@ -1,0 +1,96 @@
+/*
+  -----------------------
+  ElegantOTA - Stop Traffic Example
+  -----------------------
+
+  This example checks a flag 
+  -------------------------------
+
+  Upgrade to ElegantOTA Pro: https://elegantota.pro
+*/
+
+#if defined(ESP8266)
+  #include <ESP8266WiFi.h>
+  #include <ESPAsyncTCP.h>
+#elif defined(ESP32)
+  #include <WiFi.h>
+  #include <AsyncTCP.h>
+#elif defined(TARGET_RP2040) || defined(TARGET_RP2350) || defined(PICO_RP2040) || defined(PICO_RP2350)
+  #include <WiFi.h>
+  #include <RPAsyncTCP.h>
+#endif
+
+#include <ESPAsyncWebServer.h>
+#include <ElegantOTA.h>
+
+const char* ssid = "........";
+const char* password = "........";
+
+AsyncWebServer server(80);
+
+unsigned long ota_progress_millis = 0;
+
+bool OTAinProgress = false;
+
+void onOTAStart() {
+  // Log when OTA has started
+  Serial.println("OTA update started!");
+  OTAinProgress = true;
+  // <Add your own code here>
+}
+
+void onOTAProgress(size_t current, size_t final) {
+  // Log every 1 second
+  if (millis() - ota_progress_millis > 1000) {
+    ota_progress_millis = millis();
+    Serial.printf("OTA Progress Current: %u bytes, Final: %u bytes\n", current, final);
+  }
+}
+
+void onOTAEnd(bool success) {
+  // Log when OTA has finished
+  if (success) {
+    Serial.println("OTA update finished successfully!");
+  } else {
+    Serial.println("There was an error during OTA update!");
+  }
+  // <Add your own code here>
+}
+
+void setup(void) {
+  Serial.begin(115200);
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid, password);
+  Serial.println("");
+
+  // Wait for connection
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("");
+  Serial.print("Connected to ");
+  Serial.println(ssid);
+  Serial.print("IP address: ");
+  Serial.println(WiFi.localIP());
+
+  server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "Hi! This is ElegantOTA AsyncDemo.");
+  });
+
+  ElegantOTA.begin(&server);    // Start ElegantOTA
+  // ElegantOTA callbacks
+  ElegantOTA.onStart(onOTAStart);
+  ElegantOTA.onProgress(onOTAProgress);
+  ElegantOTA.onEnd(onOTAEnd);
+
+  server.begin();
+  Serial.println("HTTP server started");
+}
+
+void loop(void) {
+  ElegantOTA.loop();
+  if (!OTAinProgress) {
+    // do other loop stuff
+  }
+}

--- a/examples/StopTrafficDemo/StopTrafficDemo.ino
+++ b/examples/StopTrafficDemo/StopTrafficDemo.ino
@@ -48,6 +48,8 @@ void onOTAProgress(size_t current, size_t final) {
 }
 
 void onOTAEnd(bool success) {
+  // decide if you want to restart loop actions before rebooting...
+  OTAinProgress = false;
   // Log when OTA has finished
   if (success) {
     Serial.println("OTA update finished successfully!");


### PR DESCRIPTION
I have a lot of ESP32 projects that have significant web traffic (page updates, SSE, etc). I found that OTA updates frequently fail if there is too much TCP/IP traffic; sometimes I hit OOM conditions in the TCP drivers or other issues. So I added a flag; if the flag is set, ElegantOTA is the only "thread" that runs. Other activities are paused until the update completes and resets the flag.
